### PR TITLE
Fix rendering triangles

### DIFF
--- a/spec/rabpt_spec.rb
+++ b/spec/rabpt_spec.rb
@@ -27,4 +27,8 @@ describe 'Rabpt' do
   it "can run RefractionTestScene" do
     expect(execute(mode: 5).success?).to be(true)
   end
+
+  it "can run TriangleTestScene" do
+    expect(execute(mode: 6).success?).to be(true)
+  end
 end

--- a/src/dependencies.rb
+++ b/src/dependencies.rb
@@ -52,6 +52,7 @@ require 'scenes/blinn_test_scene'
 require 'scenes/camera_test_scene'
 require 'scenes/instancing_test_scene'
 require 'scenes/mesh_loading_test_scene'
+require 'scenes/triangle_test_scene'
 require 'scenes/refraction_test_scene'
 
 

--- a/src/dependencies.rb
+++ b/src/dependencies.rb
@@ -18,7 +18,6 @@ require 'light_geometry'
 require 'light_list'
 require 'ray'
 require 'renderer'
-require 'rendering_task'
 require 'sampler'
 require 'sampler_factory'
 require 'scene'
@@ -55,3 +54,8 @@ require 'scenes/instancing_test_scene'
 require 'scenes/mesh_loading_test_scene'
 require 'scenes/refraction_test_scene'
 
+
+if RUBY_PLATFORM == 'java'
+  require 'java'
+  require 'rendering_task'
+end

--- a/src/integrators/debug_integrator.rb
+++ b/src/integrators/debug_integrator.rb
@@ -17,7 +17,7 @@ class DebugIntegrator
 
     return contribution if hit_record.nil?
 
-    if hit_record.positive?
+    if hit_record.t.positive?
       # render green if hit point was "in front" of ray origin
       Spectrum.new(Vector3f.new(0.0, 1.0, 0.0))
     else

--- a/src/intersectables/mesh_triangle.rb
+++ b/src/intersectables/mesh_triangle.rb
@@ -11,10 +11,9 @@ class MeshTriangle
   # TODO explain beta_gama
   def initialize(mesh, index)
     @mesh = mesh
-    facs = mesh.indices[index + 1]
-
-    verts = mesh.vertices.values_at(facs.x, facs.y, facs.z)
-    norms = mesh.normals.values_at(facs.x, facs.y, facs.z)
+    faces = mesh.indices[index]
+    verts = mesh.vertices.values_at(faces.x, faces.y, faces.z)
+    norms = mesh.normals.values_at(faces.x, faces.y, faces.z)
 
     # spanning triangle points
     @p_x = verts[0]

--- a/src/intersectables/mesh_triangle.rb
+++ b/src/intersectables/mesh_triangle.rb
@@ -90,16 +90,21 @@ class MeshTriangle
     a.add(b).add(c).normalize
   end
 
-  # use BC coordinates
-  # was triangle intersected
-  def inside_triangle?(beta, gamma)
-    no_triangle_hit = [beta, gamma].any? do |expression|
-      expression >= 0.0 && 1 >= expression
-    end
+  # if 0 < a*t + b < 1 then we are below line.
+  # if we are below two intersecting lines, then we are inside a triangle.
+  #
+  # @param t1 [Float] parameter of affine line
+  # @param t2 [Float] parameter of affine line
+  # @return [Boolean] true if we are inside a triangle spanned by 3 lines
+  def inside_triangle?(t1, t2)
+    outside_line1 = t1 <= 0.0 || t1 >= 1.0
+    outside_line2 = t2 <= 0.0 || t2 >= 1.0
 
-    return false if no_triangle_hit
+    # conservative inside check
+    return false if outside_line1 || outside_line2
 
-    value = gamma + beta
-    value >= 0.0 && 1 >= value
+    # parameterization within
+    t = t1 + t2
+    t > 0.0 && t < 1.0
   end
 end

--- a/src/intersectables/mesh_triangle.rb
+++ b/src/intersectables/mesh_triangle.rb
@@ -16,8 +16,6 @@ class MeshTriangle
     verts = mesh.vertices.values_at(facs.x, facs.y, facs.z)
     norms = mesh.normals.values_at(facs.x, facs.y, facs.z)
 
-    puts "#{facs} #{verts.map(&:to_s).inspect} #{index}"
-
     # spanning triangle points
     @p_x = verts[0]
     @p_y = verts[1]

--- a/src/renderer.rb
+++ b/src/renderer.rb
@@ -69,6 +69,8 @@ class Renderer
                     MeshLoadingTestScene
                   when 5
                     RefractionTestScene
+                  when 6
+                    TriangleTestScene
                   else
                     CameraTestScene
                   end

--- a/src/renderer.rb
+++ b/src/renderer.rb
@@ -8,16 +8,13 @@ class Renderer
   OUTPUT_PATH           = 'output/'.freeze
 
   if RUBY_PLATFORM == 'java'
-    require 'java'
-    require_relative 'rendering_task.rb'
-
     java_import 'java.util.concurrent.Callable'
     java_import 'java.util.concurrent.FutureTask'
     java_import 'java.util.concurrent.LinkedBlockingQueue'
     java_import 'java.util.concurrent.ThreadPoolExecutor'
     java_import 'java.util.concurrent.TimeUnit'
     java_import 'java.lang.Runtime'
-    CORE_POOL_THREADS = Runtime.getRuntime.availableProcessors
+    CORE_POOL_THREADS = Runtime.get_runtime.available_processors
   end
 
   attr_accessor :image,
@@ -112,14 +109,18 @@ class Renderer
     num_tasks.times do |k|
       block[:ymin] = k * delta_height + 1
       block[:ymax] = (k + 1) * delta_height
-      tasks << FutureTask.new(RenderingTask.new(block, scene, integrator, sampler))
+      tasks << FutureTask.new(
+        RenderingTask.new(block, scene, integrator, sampler)
+      )
     end
 
     # handle reminder rows
     if reminder_rows > 0
       block[:ymin] = scene.height - reminder_rows + 1
       block[:ymax] = scene.height + 1
-      tasks << FutureTask.new(RenderingTask.new(block, scene, integrator, sampler))
+      tasks << FutureTask.new(
+        RenderingTask.new(block, scene, integrator, sampler)
+      )
     end
 
     print 'Progress: '
@@ -190,7 +191,7 @@ class Renderer
     stars = PROGRESS_STAR_COUNT
 
     num_tasks = (scene.height / ROW_NUMBER_PER_THREAD).to_i
-    reminder_rows = scene.height - num_tasks*ROW_NUMBER_PER_THREAD
+    reminder_rows = scene.height - num_tasks * ROW_NUMBER_PER_THREAD
     num_tasks += 1 if reminder_rows > 0
     pixels_per_star = (num_tasks / stars).to_i
     (pixels_per_star < 1) ? 1 : pixels_per_star

--- a/src/rendering_task.rb
+++ b/src/rendering_task.rb
@@ -1,6 +1,3 @@
-# used to call java code
-require 'java'
-
 java_import 'java.util.concurrent.Callable'
 java_import 'java.util.concurrent.FutureTask'
 java_import 'java.util.concurrent.LinkedBlockingQueue'
@@ -34,20 +31,20 @@ class RenderingTask
   private
 
   def compute_contribution
-    @x_range.each do |j|
-      @y_range.each do |i|
-        samples = @integrator.make_pixel_samples(@sampler, @scene.spp);
+    x_range.each do |j|
+      y_range.each do |i|
+        samples = integrator.make_pixel_samples(sampler, scene.spp);
         # for N sampels per pixel
         (1..samples.length).each do |k|
 
           # make ray
-          ray = @scene.camera.make_world_space_ray(i, j, samples[k-1])
+          ray = scene.camera.make_world_space_ray(i, j, samples[k-1])
 
           # evaluate ray
-          ray_spectrum = @integrator.integrate(ray)
+          ray_spectrum = integrator.integrate(ray)
 
           # write to film
-          @scene.film.add_sample(
+          scene.film.add_sample(
             i.to_f + samples[k-1][0].to_f,
             j.to_f + samples[k-1][1].to_f,
             ray_spectrum

--- a/src/scenes/triangle_test_scene.rb
+++ b/src/scenes/triangle_test_scene.rb
@@ -1,0 +1,56 @@
+class TriangleTestScene
+  include Scene
+
+  def initialize(width, height, spp)
+    @width  = width
+    @height = height
+    @spp    = spp
+
+    eye     = Vector3f.new(0.0, 0.0, 3.0)
+    look_at = Vector3f.new(0.0, 0.0, 0.0)
+    up      = Vector3f.new(0.0, 1.0, 0.0)
+    fov     = 60.0
+    aspect  = @width.to_f / @height.to_f
+
+    camera_args = {
+      eye: eye,
+      look_at: look_at,
+      up: up,
+      fov: fov,
+      aspect_ratio: aspect,
+      width: @width,
+      height: @height
+    }
+
+    @camera = Camera.new(camera_args)
+    @film = BoxFilterFilm.new(width, height)
+    @integrator_factory = DebugIntegratorFactory.new
+    @sampler_factory = OneSamplerFactory.new
+
+    mesh_data = {
+      vertices: [
+        Vector3f.new(0.0, 0.0, 0.0),
+        Vector3f.new(1.0, 0.0, 0.0),
+        Vector3f.new(0.0, 1.0, 0.0)
+      ],
+      normals: [
+        Vector3f.new(0.0, 0.0, 1.0),
+        Vector3f.new(0.0, 0.0, 1.0),
+        Vector3f.new(0.0, 0.0, 1.0)
+      ],
+      faces: [
+        Vector3f.new(0, 1, 2)
+      ]
+    }
+
+    mesh = Mesh.new(mesh_data, nil)
+    intersectable_list = IntersectableList.new
+    intersectable_list.put(Instance.new(mesh, Matrix4f.identity))
+
+    @root = intersectable_list
+  end
+
+  def base_name
+    'triangle_test_scene'
+  end
+end

--- a/src/util/obj_reader.rb
+++ b/src/util/obj_reader.rb
@@ -2,8 +2,6 @@
 # for further information please have a look at:
 # http://en.wikipedia.org/wiki/Wavefront_.obj_file
 class ObjReader
-  ObjReader::BASEPATH = 'meshes/'.freeze
-
   attr_reader :mesh_data,
               :x_min, :x_max,
               :y_min, :y_max,
@@ -13,7 +11,7 @@ class ObjReader
   #        the file name of the target
   #        obj file + its extension
   # E.g. file_name = "teapot.obj"
-  def initialize file_name
+  def initialize(file_name)
     @x_min = Float::MAX
     @y_min = Float::MAX
     @z_min = Float::MAX
@@ -29,10 +27,10 @@ class ObjReader
     vertex_counter = 1
     normal_counter = 1
     face_counter = 1
-    path = ObjReader::BASEPATH + file_name
-    file = File.new(path, "r")
+    file_path = File.join('meshes', file_name)
+    file = File.read(file_path)
 
-    while (line = file.gets)
+    file.split(/\n/).each do |line|
       arguments = line.split
       case arguments[0]
       when "v"
@@ -63,7 +61,6 @@ class ObjReader
       end
       counter = counter + 1
     end
-    file.close
 
     # number vertex noramls corresponds to number of mesh vertices
     normals = normals.reject do |key|

--- a/src/util/obj_reader.rb
+++ b/src/util/obj_reader.rb
@@ -23,10 +23,10 @@ class ObjReader
     faces = {}
     normals = {}
 
-    counter = 1
+    counter = 0
     vertex_counter = 1
     normal_counter = 1
-    face_counter = 1
+    face_counter = 0
     file_path = File.join('meshes', file_name)
     file = File.read(file_path)
 
@@ -53,6 +53,8 @@ class ObjReader
 				normal = Vector3f.make_from_floats(arguments[1..3].map &:to_f)
         normals[normal_counter] = normal.normalize
         normal_counter += 1
+      when "vt"
+        # TODO: impelement reading tangents
 
       when "#"
         # meta mesh information


### PR DESCRIPTION
First round of bug-fixes that are related to meshes. 

This patch addresses the following main triangle issues:
+ triangle face indices were mapped to the wrong vertices
+ the conservative "is inside triangle" was incorrect

Moreover, I added a triangle test scene to validate the functionality. Please notice that currently no other than the debug integrator can be used in combination with meshes to generate scene. There are other issues present that relate to the mesh's hit record. But this will be addressed in a follow-up MR.